### PR TITLE
Remove tabIndex

### DIFF
--- a/UDPSearch/UDPSearch.js
+++ b/UDPSearch/UDPSearch.js
@@ -58,7 +58,6 @@ class UDPSearch extends Component {
               buttonStyle={searchButtonStyle}
               onClick={this.openModal}
               aria-label={ariaLabel}
-              tabIndex="-1"
               marginBottom0={marginBottom0}
               marginTop0={marginTop0}
             >


### PR DESCRIPTION
Setting `tabIndex="-1"` makes the button inaccessible for keyboard users.