### PR TITLE
Pass a ref to the modal to restore focus on the trigger button, refs …

### DIFF
--- a/UDPSearch/UDPSearch.js
+++ b/UDPSearch/UDPSearch.js
@@ -3,6 +3,7 @@ import { FormattedMessage } from 'react-intl';
 import PropTypes from 'prop-types';
 import { Button, Icon } from '@folio/stripes/components';
 import className from 'classnames';
+import contains from 'dom-helpers/query/contains';
 
 import css from './UDPSearch.css';
 import UDPSearchModal from './UDPSearchModal';
@@ -17,6 +18,8 @@ class UDPSearch extends Component {
 
     this.openModal = this.openModal.bind(this);
     this.closeModal = this.closeModal.bind(this);
+    this.modalTrigger = React.createRef();
+    this.modalRef = React.createRef();
   }
 
   getStyle() {
@@ -36,6 +39,23 @@ class UDPSearch extends Component {
   closeModal() {
     this.setState({
       openModal: false,
+    }, () => {
+      if (this.modalRef.current && this.modalTrigger.current) {
+        if (contains(this.modalRef.current, document.activeElement)) {
+          this.modalTrigger.current.focus();
+        }
+      }
+    });
+  }
+
+  renderTriggerButton() {
+    const {
+      renderTrigger,
+    } = this.props;
+
+    return renderTrigger({
+      buttonRef: this.modalTrigger,
+      onClick: this.openModal,
     });
   }
 
@@ -43,27 +63,32 @@ class UDPSearch extends Component {
     const {
       buttonId,
       marginBottom0,
+      renderTrigger,
       searchButtonStyle,
       searchLabel,
     } = this.props;
 
     return (
       <div className={this.getStyle()}>
-        <FormattedMessage id="ui-plugin-find-erm-usage-data-provider.searchButton.title">
-          {ariaLabel => (
-            <Button
-              id={buttonId}
-              key="searchButton"
-              buttonStyle={searchButtonStyle}
-              onClick={this.openModal}
-              aria-label={ariaLabel}
-              marginBottom0={marginBottom0}
-            >
-              {searchLabel || <Icon icon="search" color="#fff" />}
-            </Button>
-          )}
-        </FormattedMessage>
+        {renderTrigger ?
+          this.renderTriggerButton() :
+          <FormattedMessage id="ui-plugin-find-erm-usage-data-provider.searchButton.title">
+            {ariaLabel => (
+              <Button
+                id={buttonId}
+                key="searchButton"
+                buttonStyle={searchButtonStyle}
+                buttonRef={this.modalTrigger}
+                onClick={this.openModal}
+                aria-label={ariaLabel}
+                marginBottom0={marginBottom0}
+              >
+                {searchLabel || <Icon icon="search" color="#fff" />}
+              </Button>
+            )}
+          </FormattedMessage>}
         <UDPSearchModal
+          modalRef={this.modalRef}
           open={this.state.openModal}
           onClose={this.closeModal}
           {...this.props}
@@ -80,6 +105,7 @@ UDPSearch.defaultProps = {
 
 UDPSearch.propTypes = {
   buttonId: PropTypes.string,
+  renderTrigger: PropTypes.func,
   searchLabel: PropTypes.node,
   searchButtonStyle: PropTypes.string,
   marginBottom0: PropTypes.bool,

--- a/UDPSearch/UDPSearchModal.js
+++ b/UDPSearch/UDPSearchModal.js
@@ -22,6 +22,7 @@ export default class UDPSearchModal extends Component {
 
     const dataKey = props.dataKey;
     this.connectedApp = props.stripes.connect(UsageDataProviders, { dataKey });
+    this.modalRef = props.modalRef || React.createRef();
   }
 
   selectUDP = (e, udp) => {
@@ -32,9 +33,11 @@ export default class UDPSearchModal extends Component {
   render() {
     return (
       <Modal
+        enforceFocus={false}
         onClose={this.props.onClose}
         size="large"
         open={this.props.open}
+        ref={this.modalRef}
         label={<FormattedMessage id="ui-plugin-find-erm-usage-data-provider.modal.label" />}
         dismissible
       >

--- a/UDPSearch/UDPSearchModal.js
+++ b/UDPSearch/UDPSearchModal.js
@@ -11,6 +11,7 @@ export default class UDPSearchModal extends Component {
     stripes: PropTypes.shape({
       connect: PropTypes.func.isRequired,
     }).isRequired,
+    modalRef: PropTypes.shape({ current: PropTypes.instanceOf(Element) }),
     onUDPSelected: PropTypes.func.isRequired,
     onClose: PropTypes.func.isRequired,
     open: PropTypes.bool,

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
   "dependencies": {
     "@folio/erm-usage": "^2.3.0",
     "classnames": "^2.2.5",
-    "prop-types": "^15.6.0"
+    "prop-types": "^15.6.0",
+    "dom-helpers":"^3.4.0"
   },
   "peerDependencies": {
     "@folio/stripes": "^2.11.0",


### PR DESCRIPTION
…UIEUS-125

Also added the `renderTrigger` optional render function for the button to open the usage data modal. This function can be used to pass back the ref for the trigger button back to the parent to focus it, for example: whenever a new field is rendered as a part of a repeatableField

