### PR TITLE
[FOLIO-4086] Fix GitHub Actions workflow not running for tags

### DIFF
--- a/.github/workflows/ui.yml
+++ b/.github/workflows/ui.yml
@@ -8,6 +8,6 @@ jobs:
   ui:
     # Use the shared workflow from https://github.com/folio-org/.github
     uses: folio-org/.github/.github/workflows/ui.yml@v1
-    # Only handle push events from the main branch, to decrease noise
-    # if: github.ref_name == github.event.repository.default_branch || github.event_name != 'push'
+    # Only handle push events from the main branch or tags, to decrease PR noise
+    # if: github.ref_name == github.event.repository.default_branch || github.event_name != 'push' || github.ref_type == 'tag'
     secrets: inherit

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 * Change class to function components and refactor away from default props for functional components([UIPFUDP-35](https://folio-org.atlassian.net/browse/UIPFUDP-35))
 * Update to usage-data-providers 3.0 ([UIPFUDP-41](https://folio-org.atlassian.net/browse/UIPFUDP-41))
 * Remove dependency to stripes-acq-components, use mocks local ([UIPFUDP-40](https://folio-org.atlassian.net/browse/UIPFUDP-40))
+* Fix GitHub Actions workflow not running for tags ([FOLIO-4086](https://folio-org.atlassian.net/browse/FOLIO-4086))
 
 ## [6.0.0](https://github.com/folio-org/ui-plugin-find-erm-usage-data-provider/tree/v6.0.0) (2023-10-12)
 * Upgrade React to v18([UIPFUDP-30](https://issues.folio.org/browse/UIPFUDP-30))


### PR DESCRIPTION
# [Jira FOLIO-4086](https://folio-org.atlassian.net/browse/FOLIO-4086)

Due to an error in the [recommended configuration for shared workflows](https://github.com/folio-org/.github/blob/master/README-UI.md), an incorrect conditional was added to the workflow which can cause GitHub Actions to not run on tags, making it impossible to release this module.

This PR resolves this by adjusting the condition to always run the workflow for pushes to tags.
